### PR TITLE
Add support for configuration overrides.

### DIFF
--- a/low_random/pi.low_random.php
+++ b/low_random/pi.low_random.php
@@ -214,15 +214,13 @@ class Low_random {
 		if (is_numeric($folder))
 		{
 			// get server path from upload prefs
-			$query = ee()->db->select('server_path')
-			       ->from('upload_prefs')
-			       ->where('id', $folder)
-			       ->get();
+			ee()->load->model('file_upload_preferences_model');
+			$upload_prefs = ee()->file_upload_preferences_model->get_file_upload_preferences(1, $folder);
 
 			// Do we have a match? get path
-			if ($query->num_rows())
+			if ($upload_prefs)
 			{
-				$folder = $query->row('server_path');
+				$folder = $upload_prefs['server_path'];
 			}
 		}
 


### PR DESCRIPTION
Support for overriding file upload preferences was added to
ExpressionEngine in version 2.4.0. The overrides are applied when
accessing the upload preferences through the file upload preferences
model. This commit modifies file randomization to use the file upload
preferences model to retrieve the server_path instead of accessing the
database directly.
